### PR TITLE
base64.encodestring is deprecated

### DIFF
--- a/ddns-update
+++ b/ddns-update
@@ -85,7 +85,7 @@ class Record:
 
         data = urllib.parse.urlencode(values).encode("utf-8")
         req = urllib.request.Request(url, data)
-        base64_user_pass = base64.encodestring(
+        base64_user_pass = base64.encodebytes(
             ('%s:%s' % (self.user, self.password)).encode()).decode().replace('\n', '')
         req.add_header('Authorization', 'Basic %s' % base64_user_pass)
         response = urllib.request.urlopen(req)


### PR DESCRIPTION
This is what I get when I ran systemtcl status ddns-update.service

```
Jul 18 06:26:18 serverPc1 systemd[1]: Started Google ddns updater.
Jul 18 06:26:19 serverPc1 python3[17307]: Traceback (most recent call last):
Jul 18 06:26:19 serverPc1 python3[17307]:   File "/usr/bin/ddns-update", line 174, in <module>
Jul 18 06:26:19 serverPc1 python3[17307]:     record.update_ip(current_ip)
Jul 18 06:26:19 serverPc1 python3[17307]:   File "/usr/bin/ddns-update", line 88, in update_ip
Jul 18 06:26:19 serverPc1 python3[17307]:     base64_user_pass = base64.encodestring(
**Jul 18 06:26:19 serverPc1 python3[17307]: AttributeError: module 'base64' has no attribute 'encodestring'**
Jul 18 06:26:19 serverPc1 systemd[1]: ddns-update.service: Main process exited, code=exited, status=1/FAILURE
Jul 18 06:26:19 serverPc1 systemd[1]: ddns-update.service: Failed with result 'exit-code'
```
base64.encodestring is deprecated recently since python 3.8 or 3.9, switching to encodebytes does the job beautifully.
Thank you for this repository lol, it worked perfectly for me.